### PR TITLE
Add (optional) logger to log failed token fetch requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "psr/cache": "^1.0",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
+    "psr/log": "^1.1",
     "zendframework/zend-diactoros": "^1.8"
   },
   "require-dev": {
-    "escapestudios/symfony2-coding-standard": "^3.4",
-    "phpunit/phpunit": "^6.5",
-    "squizlabs/php_codesniffer": "^3.3"
+    "myonlinestore/coding-standard": "^1.0",
+    "phpunit/phpunit": "^6.5"
   },
   "config": {
     "vendor-dir": "vendor",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,26 +1,17 @@
 <?xml version="1.0"?>
-<ruleset name="MyOnlineStore">
-    <description>MyOnlineStore coding standard</description>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <arg value="sp"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
 
-    <file>src</file>
+    <file>./src/</file>
+    <file>./tests/</file>
 
-    <exclude-pattern>tests/*</exclude-pattern>
-
-    <!-- Include the whole Symfony2 standard -->
-    <rule ref="vendor/escapestudios/symfony2-coding-standard/Symfony/ruleset.xml"/>
-
-    <rule ref="Symfony">
-        <exclude name="Symfony.Commenting.ClassComment.Missing"/>
-        <exclude name="Symfony.Commenting.FunctionComment.Missing"/>
-        <exclude name="Symfony.Commenting.License.Warning"/>
-        <exclude name="Symfony.Functions.Arguments.Invalid"/>
-    </rule>
-
-    <!-- The soft limit on line length MUST be 120 characters; automated style checkers MUST warn but MUST NOT error at the soft limit. -->
-    <rule ref="Generic.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="120"/>
-            <property name="absoluteLineLimit" value="0"/>
-        </properties>
+    <rule ref="vendor/myonlinestore/coding-standard/MyOnlineStore/ruleset.xml">
+        <exclude name="Symfony.NamingConventions.ValidClassName.InvalidInterfaceName"/>
+        <exclude name="Symfony.NamingConventions.ValidClassName.InvalidExceptionName"/>
     </rule>
 </ruleset>

--- a/src/TokenManager/Jwt.php
+++ b/src/TokenManager/Jwt.php
@@ -23,7 +23,9 @@ final class Jwt implements TokenManagerInterface
      */
     private $jwtParser;
 
-    /** @var LoggerInterface */
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
     /**

--- a/src/TokenManager/Jwt.php
+++ b/src/TokenManager/Jwt.php
@@ -8,6 +8,8 @@ use GuzzleHttp\Exception\GuzzleException;
 use Lcobucci\JWT\Parser;
 use MyOnlineStore\GuzzleAuthorizationMiddleware\Token;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final class Jwt implements TokenManagerInterface
 {
@@ -20,6 +22,9 @@ final class Jwt implements TokenManagerInterface
      * @var Parser
      */
     private $jwtParser;
+
+    /** @var LoggerInterface */
+    private $logger;
 
     /**
      * @var RequestFactoryInterface
@@ -35,17 +40,17 @@ final class Jwt implements TokenManagerInterface
         ClientInterface $httpClient,
         Parser $jwtParser,
         RequestFactoryInterface $requestFactory,
-        UriProviderInterface $uriProvider
+        UriProviderInterface $uriProvider,
+        LoggerInterface $logger = null
     ) {
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->uriProvider = $uriProvider;
         $this->jwtParser = $jwtParser;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
-     * @return Token
-     *
      * @throws \InvalidArgumentException If the token is not a valid JWT
      * @throws \OutOfBoundsException     If the token does not have an exp claim
      */
@@ -63,6 +68,14 @@ final class Jwt implements TokenManagerInterface
 
             $token = \json_decode($response->getBody()->getContents(), true)['accessToken'] ?? '';
         } catch (GuzzleException $exception) {
+            $this->logger->critical(
+                'Unable to fetch JWT token',
+                [
+                    'message' => $exception->getMessage(),
+                    'previous' => $exception->getPrevious(),
+                    'trace' => $exception->getTraceAsString(),
+                ]
+            );
         }
 
         return new Token(

--- a/tests/TokenManager/JwtTest.php
+++ b/tests/TokenManager/JwtTest.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
 
 final class JwtTest extends TestCase
 {
@@ -35,6 +36,11 @@ final class JwtTest extends TestCase
     private $jwtParser;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @var RequestFactoryInterface
      */
     private $requestFactory;
@@ -50,7 +56,8 @@ final class JwtTest extends TestCase
             $this->httpClient = $this->createMock(ClientInterface::class),
             $this->jwtParser = $this->createMock(Parser::class),
             $this->requestFactory = $this->createMock(RequestFactoryInterface::class),
-            $this->uriProvider = $this->createMock(UriProviderInterface::class)
+            $this->uriProvider = $this->createMock(UriProviderInterface::class),
+            $this->logger = $this->createMock(LoggerInterface::class)
         );
     }
 
@@ -151,6 +158,10 @@ final class JwtTest extends TestCase
             ->method('send')
             ->with($request)
             ->willThrowException(new TransferException());
+
+        $this->logger->expects(self::once())
+            ->method('critical')
+            ->with('Unable to fetch JWT token', self::isType('array'));
 
         $this->jwtParser->expects(self::once())
             ->method('parse')


### PR DESCRIPTION
Allows a logger to be injected so failed token requests can be logged.
Also updated phpcs to use the mos/cs package.